### PR TITLE
Database refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuration for [pipenv](https://pipenv.readthedocs.io/en/latest/)
 
 ## Changed
+- Use a database management class with Python context management to automatically open/close connections and cursors
+
+## Changed
 - Validate code against PEP 8 style guide with Flake8
 
 ### [0.6.1] - 2018-10-31

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ The item id is the *internal* id for an item. You can get these from the standar
 
 ## Todo
 
-- Close DB connection when gunicorn shuts down gracefully
 - Better logging
 - Tests
 - Check if database exists (try/except)

--- a/dspace_statistics_api/app.py
+++ b/dspace_statistics_api/app.py
@@ -1,8 +1,5 @@
-from .database import database_connection
+from .database import DatabaseManager
 import falcon
-
-db = database_connection()
-db.set_session(readonly=True)
 
 
 class RootResource:
@@ -21,23 +18,23 @@ class AllItemsResource:
         page = req.get_param_as_int("page", min=0) or 0
         offset = limit * page
 
-        cursor = db.cursor()
+        with DatabaseManager() as db:
+            db.set_session(readonly=True)
 
-        # get total number of items so we can estimate the pages
-        cursor.execute('SELECT COUNT(id) FROM items')
-        pages = round(cursor.fetchone()[0] / limit)
+            with db.cursor() as cursor:
+                # get total number of items so we can estimate the pages
+                cursor.execute('SELECT COUNT(id) FROM items')
+                pages = round(cursor.fetchone()[0] / limit)
 
-        # get statistics, ordered by id, and use limit and offset to page through results
-        cursor.execute('SELECT id, views, downloads FROM items ORDER BY id ASC LIMIT {} OFFSET {}'.format(limit, offset))
+                # get statistics, ordered by id, and use limit and offset to page through results
+                cursor.execute('SELECT id, views, downloads FROM items ORDER BY id ASC LIMIT {} OFFSET {}'.format(limit, offset))
 
-        # create a list to hold dicts of item stats
-        statistics = list()
+                # create a list to hold dicts of item stats
+                statistics = list()
 
-        # iterate over results and build statistics object
-        for item in cursor:
-            statistics.append({'id': item['id'], 'views': item['views'], 'downloads': item['downloads']})
-
-        cursor.close()
+                # iterate over results and build statistics object
+                for item in cursor:
+                    statistics.append({'id': item['id'], 'views': item['views'], 'downloads': item['downloads']})
 
         message = {
             'currentPage': page,
@@ -53,25 +50,27 @@ class ItemResource:
     def on_get(self, req, resp, item_id):
         """Handles GET requests"""
 
-        cursor = db.cursor()
-        cursor.execute('SELECT views, downloads FROM items WHERE id={}'.format(item_id))
-        if cursor.rowcount == 0:
-            raise falcon.HTTPNotFound(
-                title='Item not found',
-                description='The item with id "{}" was not found.'.format(item_id)
-            )
-        else:
-            results = cursor.fetchone()
+        with DatabaseManager() as db:
+            db.set_session(readonly=True)
 
-            statistics = {
-                'id': item_id,
-                'views': results['views'],
-                'downloads': results['downloads']
-            }
+            with db.cursor() as cursor:
+                cursor = db.cursor()
+                cursor.execute('SELECT views, downloads FROM items WHERE id={}'.format(item_id))
+                if cursor.rowcount == 0:
+                    raise falcon.HTTPNotFound(
+                        title='Item not found',
+                        description='The item with id "{}" was not found.'.format(item_id)
+                    )
+                else:
+                    results = cursor.fetchone()
 
-            resp.media = statistics
+                    statistics = {
+                        'id': item_id,
+                        'views': results['views'],
+                        'downloads': results['downloads']
+                    }
 
-        cursor.close()
+                    resp.media = statistics
 
 
 api = application = falcon.API()

--- a/dspace_statistics_api/database.py
+++ b/dspace_statistics_api/database.py
@@ -7,9 +7,17 @@ import psycopg2
 import psycopg2.extras
 
 
-def database_connection():
-    connection = psycopg2.connect("dbname={} user={} password={} host={} port={}".format(DATABASE_NAME, DATABASE_USER, DATABASE_PASS, DATABASE_HOST, DATABASE_PORT), cursor_factory=psycopg2.extras.DictCursor)
+class DatabaseManager():
+    '''Manage database connection.'''
 
-    return connection
+    def __init__(self):
+        self._connection_uri = 'dbname={} user={} password={} host={} port={}'.format(DATABASE_NAME, DATABASE_USER, DATABASE_PASS, DATABASE_HOST, DATABASE_PORT)
+
+    def __enter__(self):
+        self._connection = psycopg2.connect(self._connection_uri, cursor_factory=psycopg2.extras.DictCursor)
+        return self._connection
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._connection.close()
 
 # vim: set sw=4 ts=4 expandtab:

--- a/dspace_statistics_api/indexer.py
+++ b/dspace_statistics_api/indexer.py
@@ -158,8 +158,6 @@ def index_downloads():
 
 solr = solr_connection()
 
-print("gonna create the table")
-
 with DatabaseManager() as db:
     with db.cursor() as cursor:
         # create table to store item views and downloads


### PR DESCRIPTION
Instead of opening one global persistent database connection when the application I am now abstracting it to a class that I can use in combination with Python's "with" context. Both connections and cursors are kept for the context of each "with" block and closed automatically when exiting.

See: https://alysivji.github.io/managing-resources-with-context-managers-pythonic.html
See: http://initd.org/psycopg/docs/connection.html#connection.close