### PR TITLE
Rework to use pip instead of pipenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+## Changed
+- README.md to recommend using vanilla Python virtual environments and pip instead of pipenv
+
+## Added
+- `requirements-dev.txt` for installing development packages with pip
+
 ## [0.8.0] - 2018-11-11
 ### Changed
 - Properly handle database connection errors

--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ ipython = "*"
 pytest = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "da754a9f6c668303b071155fdd3a31067897f2c1703a28990745506a5ea55538"
+            "sha256": "efc8ac5e45868d93f6bd9c363dc649f4031192c9d55e87eda94aa8e7a064918c"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ This project contains an indexer and a [Falcon-based](https://falcon.readthedocs
 - PostgreSQL version 9.5+ (due to [`UPSERT` support](https://wiki.postgresql.org/wiki/UPSERT))
 - DSpace with [Solr usage statistics enabled](https://wiki.duraspace.org/display/DSDOC5x/SOLR+Statistics) (tested with 5.x)
 
-## Installation and Testing
-Create a Python virtual environment and install the dependencies using [`pipenv`](https://github.com/pypa/pipenv):
+## Installation
+Create a Python virtual environment and install the dependencies:
 
-    $ pipenv install --dev
-    $ pipenv shell
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+
+## Running
 
 Set up the environment variables for Solr and PostgreSQL:
 
@@ -34,6 +37,11 @@ Run the REST API:
 Test to see if there are any statistics:
 
     $ curl 'http://localhost:8000/items?limit=1'
+
+## Testing
+Install development packages using pip:
+
+    $ pip install -r requirements-dev.txt
 
 Run tests:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,25 @@
+-i https://pypi.org/simple
+atomicwrites==1.2.1
+attrs==18.2.0
+backcall==0.1.0
+decorator==4.3.0
+flake8==3.6.0
+ipython-genutils==0.2.0
+ipython==7.1.1
+jedi==0.13.1
+mccabe==0.6.1
+more-itertools==4.3.0
+parso==0.3.1
+pexpect==4.6.0 ; sys_platform != 'win32'
+pickleshare==0.7.5
+pluggy==0.8.0
+prompt-toolkit==2.0.7
+ptyprocess==0.6.0
+py==1.7.0
+pycodestyle==2.4.0
+pyflakes==2.0.0
+pygments==2.2.0
+pytest==3.10.1
+six==1.11.0
+traitlets==4.3.2
+wcwidth==0.1.7


### PR DESCRIPTION
Pipenv is great for local development, but I don't think many people are using it yet. I can use it locally and on Travis, but still keep vanilla requirements.txt for use with pip. The `requirements.txt` and `requirements-dev.txt` file can be generated easily from pipenv itself:

    $ pipenv lock -r > requirements.txt
    $ pipenv lock -r -d > requirements-dev.txt